### PR TITLE
Dramatically improve H2O scaler performance

### DIFF
--- a/skutil/h2o/transform.py
+++ b/skutil/h2o/transform.py
@@ -370,11 +370,15 @@ class H2OSelectiveScaler(BaseH2OTransformer):
         if (not self.with_mean) and (not self.with_std):
             return frame  # nothing to change...
 
+        # assignment is expensive in H2O... let's only assign ONCE and not inplace:
         for nm in self.cols_:
-            if self.with_mean:
-                frame[nm] -= self.means[nm]
-            if self.with_std:
-                frame[nm] /= self.stds[nm]
+            col_frm = frame[nm]
+            if self.with_mean and self.with_std:
+                frame[nm] = (col_frm - self.means[nm]) / self.stds[nm]
+            elif self.with_mean:
+                frame[nm] = col_frm - self.means[nm]
+            elif self.with_std:
+                frame[nm] = col_frm / self.stds[nm]
 
         return frame
 


### PR DESCRIPTION
The previous method scaled values on a copy of the frame in-place, which is *hugely* expensive for frames with many observations. When centering and scaling, the process executed 2(NM) `set` operations. The current method simply creates N chunks that handle the computing and setting on the H2O side.